### PR TITLE
Add urg_t_initialize function and fixed sync_time_stamp sample.

### DIFF
--- a/current/include/c/urg_sensor.h
+++ b/current/include/c/urg_sensor.h
@@ -110,6 +110,32 @@ extern "C" {
         char return_buffer[80];
     } urg_t;
 
+    /*!
+      \~japanese
+      \brief urg_t構造体の初期化
+
+      URG センサ管理構造体(urg_t)を初期化します。
+
+      \param[in,out] urg URG センサ管理
+
+      \attention この関数はurg_open()の初めに実行されます。任意にセンサ管理構造体(urg_t)を初期化したい時はこの関数を呼び出してください。
+      \see urg_open()
+
+      \~english
+      \brief URG control structure (urg_t) initialization
+
+      Initialize URG control structure(urg_t)
+
+      \param[in,out] urg URG control structure
+
+      \attention
+      This function is executed at the start of urg_open ().
+      Call this function if you want to initialize the URG control structure (urg_t) arbitrarily.
+
+      \see urg_open()
+      \~
+    */
+    void urg_t_initialize(urg_t *urg);
 
     /*!
       \~japanese

--- a/current/include/cpp/Urg_driver.h
+++ b/current/include/cpp/Urg_driver.h
@@ -79,6 +79,8 @@ namespace qrk
         void stop_measurement(void);
 
         //! \~japanese タイムスタンプの同期  \~english Synchronization of timestamps
+        bool start_time_stamp_mode(void);
+        bool stop_time_stamp_mode(void);
         bool set_sensor_time_stamp(long time_stamp);
         long get_sensor_time_stamp(void);
 

--- a/current/samples/c/sync_time_stamp.c
+++ b/current/samples/c/sync_time_stamp.c
@@ -41,7 +41,7 @@ static int pc_msec_time(void)
 #else
     if (!is_initialized) {
         gettimeofday(&first_time, NULL);
-	is_initialized = 1;
+        is_initialized = 1;
     }
     gettimeofday(&current_time, NULL);
 
@@ -108,6 +108,8 @@ int main(int argc, char *argv[])
     // \~japanese URG のタイムスタンプと PC のタイムスタンプを表示
     // \~english Prints the URG timestamp and the PC timestamp
     time_stamp_offset = print_time_stamp(&urg, 0);
+
+    printf("\n");
 
     // \~japanese URG の補正後のタイムスタンプと PC タイムスタンプを表示
     // \~english Prints the URG timestamp and the PC timestamp after correction

--- a/current/samples/cpp/sync_time_stamp.cpp
+++ b/current/samples/cpp/sync_time_stamp.cpp
@@ -23,10 +23,13 @@ namespace
     void print_timestamp(Urg_driver& urg)
     {
         enum { Print_times = 3 };
+        urg.start_time_stamp_mode();
 
         for (int i = 0; i < Print_times; ++i) {
             cout << ticks() << ", " << urg.get_sensor_time_stamp() << endl;
         }
+
+        urg.stop_time_stamp_mode();
     }
 }
 
@@ -46,12 +49,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    // \~japanese データは１ステップのみ取得する
-    // \~english Will obtain only one step of measurement data
-    int min_step = urg.min_step();
-    urg.set_scanning_parameter(min_step, min_step);
+    cout << "# pc,\tsensor" << endl;
 
-    //
     // \~japanese 比較用に PC とセンサのタイムスタンプを表示する
     // \~english Just to compare, shows the current PC timestamp and sensor timestamp
     print_timestamp(urg);

--- a/current/src/Urg_driver.cpp
+++ b/current/src/Urg_driver.cpp
@@ -40,6 +40,7 @@ struct Urg_driver::pImpl
     pImpl(void)
         :last_measure_type_(Distance), time_stamp_offset_(0)
     {
+        urg_t_initialize(&urg_);
     }
 
 

--- a/current/src/Urg_driver.cpp
+++ b/current/src/Urg_driver.cpp
@@ -309,6 +309,18 @@ void Urg_driver::stop_measurement(void)
     urg_stop_measurement(&pimpl->urg_);
 }
 
+bool Urg_driver::start_time_stamp_mode(void)
+{
+    int ret = urg_start_time_stamp_mode(&pimpl->urg_);
+    return (ret < 0) ? false : true;
+}
+
+bool Urg_driver::stop_time_stamp_mode(void)
+{
+    int ret = urg_stop_time_stamp_mode(&pimpl->urg_);
+    return (ret < 0) ? false : true;
+}
+
 long Urg_driver::get_sensor_time_stamp(void)
 {
     long time_stamp = urg_time_stamp(&pimpl->urg_);


### PR DESCRIPTION
・urg_t_initialize関数を追加して、任意にurg_t構造体を初期化できるようにしました。
・C++ sync_time_stampのサンプルでUBG-04LX-F01のタイムスタンプ応答が無かったので対応できるようにしました。