### PR TITLE
Fix implicit declaration of usleep() warning

### DIFF
--- a/current/src/urg_utils.c
+++ b/current/src/urg_utils.c
@@ -12,6 +12,10 @@
 
 #include "urg_utils.h"
 #include "urg_errno.h"
+#include "urg_detect_os.h"
+#if !defined(URG_WINDOWS_OS)
+#include <unistd.h>
+#endif
 #define _USE_MATH_DEFINES
 #include <math.h>
 


### PR DESCRIPTION
Xcode Clang's default configuration treats this as an error.  Fixes #19.