### PR TITLE
Remove "const" to avoid error in Ubuntu 24.04 LTS

### DIFF
--- a/current/src/urg_sensor.c
+++ b/current/src/urg_sensor.c
@@ -1347,7 +1347,7 @@ static const char *receive_command_response(urg_t *urg,
 }
 
 
-static const int receive_II_command_response(urg_t *urg,
+static int receive_II_command_response(urg_t *urg,
                                             char *buffer, int buffer_size)
 {
     const int vv_expected[] = { 0, EXPECTED_END };


### PR DESCRIPTION
In Ubuntu 24.04 LTS, running the [build command](https://github.com/Hokuyo-aut/urg_node2) `colcon build --symlink-install` results in errors.

```
noble@noble-MacBookPro:~/Documents$  colcon build --symlink-install
Starting >>> urg_node2
--- stderr: urg_node2                                
/home/noble/Documents/lidar/urg_node2/urg_library/current/src/urg_utils.c: In function ‘urg_delay’:
/home/noble/Documents/lidar/urg_node2/urg_library/current/src/urg_utils.c:224:5: warning: implicit declaration of function ‘usleep’; did you mean ‘urg_sleep’? [-Wimplicit-function-declaration]
  224 |     usleep(1000 * delay_msec);
      |     ^~~~~~
      |     urg_sleep
/home/noble/Documents/lidar/urg_node2/urg_library/current/src/urg_sensor.c:1349:8: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
 1349 | static const int receive_II_command_response(urg_t *urg,
      |        ^~~~~
---
Finished <<< urg_node2 [16.3s]
 
Summary: 1 package finished [16.4s]
  1 package had stderr output: urg_node2
 ```

(Please disregard the implicit declaration error here, as it appears to have already been fixed in this repository.)

I'll submit a pull request [here](https://github.com/Hokuyo-aut/urg_node2) if this PR gets merged.