### PR TITLE
tcpclient_readのノンブロッキング設定を修正

### DIFF
--- a/current/src/urg_tcpclient.c
+++ b/current/src/urg_tcpclient.c
@@ -1,6 +1,6 @@
 /*!
   \file
-  \~japanese TCP/IP 読み込み/書き込み　関数 
+  \~japanese TCP/IP 読み込み/書き込み　関数
   \brief
   \~english
   \brief TCP/IP read/write functions
@@ -248,8 +248,8 @@ int tcpclient_read(urg_tcpclient_t* cli,
         char tmpbuf[BUFSIZE];
         // receive with non-blocking mode.
 #if defined(URG_WINDOWS_OS)
-        int no_timeout = 1;
-        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&no_timeout, sizeof(struct timeval));
+        u_long val = 1;
+        ioctlsocket(sock, FIONBIO, &val);
         n = recv(sock, tmpbuf, BUFSIZE - num_in_buf, 0);
 #else
         n = recv(sock, tmpbuf, BUFSIZE - num_in_buf, MSG_DONTWAIT);
@@ -269,6 +269,8 @@ int tcpclient_read(urg_tcpclient_t* cli,
     //  lastly recv with blocking but with time out to read necessary size.
     {
 #if defined(URG_WINDOWS_OS)
+        u_long val = 0;
+        ioctlsocket(sock, FIONBIO, &val);
         setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
                    (const char *)&timeout, sizeof(struct timeval));
 #else


### PR DESCRIPTION
Windows11 24H2でクラッシュする問題を解決