### PR TITLE
urg_sleep不具合修正2025/08/25

### DIFF
--- a/current/include/c/urg_sensor.h
+++ b/current/include/c/urg_sensor.h
@@ -990,7 +990,7 @@ extern "C" {
       \~
       \see urg_wakeup()
     */
-    extern void urg_sleep(urg_t *urg);
+    extern int urg_sleep(urg_t *urg);
 
 
     /*!

--- a/current/src/urg_sensor.c
+++ b/current/src/urg_sensor.c
@@ -1275,7 +1275,7 @@ int urg_sleep(urg_t *urg)
         return qtResult;
     }
 
-    int ret = scip_response(urg, "%SL\n", sl_expected, MAX_TIMEOUT,
+    int ret = scip_response(urg, "%SL\n", sl_expected, 1000,
                   receive_buffer, RECEIVE_BUFFER_SIZE);
     if (ret < 0) {
         return ret;

--- a/current/src/urg_sensor.c
+++ b/current/src/urg_sensor.c
@@ -1263,18 +1263,24 @@ int urg_reboot(urg_t *urg)
 }
 
 
-void urg_sleep(urg_t *urg)
+int urg_sleep(urg_t *urg)
 {
     enum { RECEIVE_BUFFER_SIZE = 4 };
     int sl_expected[] = { 0, EXPECTED_END };
-    char receive_buffer[RECEIVE_BUFFER_SIZE];
+    char receive_buffer[RECEIVE_BUFFER_SIZE + 1];
 
-    if (urg_stop_measurement(urg) != URG_NO_ERROR) {
-        return;
+    int qtResult = urg_stop_measurement(urg);
+
+    if (qtResult != URG_NO_ERROR) {
+        return qtResult;
     }
 
-    scip_response(urg, "%SL\n", sl_expected, MAX_TIMEOUT,
+    int ret = scip_response(urg, "%SL\n", sl_expected, MAX_TIMEOUT,
                   receive_buffer, RECEIVE_BUFFER_SIZE);
+    if (ret < 0) {
+        return ret;
+    }
+    return 0;
 }
 
 


### PR DESCRIPTION
urg_sleepの不具合を修正
・#SLコマンドのライブラリ側のタイムアウトが140msになっていたが、応答時間がそれ以上の機種があったので、1000msに変更した。
・urg_sleepメソッドの戻り値がvoidで#SLの応答を捨てていたので、戻り値をint型にして応答によって戻り値を変更するようにした。
・#SLコマンドを送るメソッドの引数のbuffer_sizeが間違っていたので修正した。(4→5)