### PR TITLE
send_distance_command不具合修正2025/08/25

### DIFF
--- a/current/src/urg_sensor.c
+++ b/current/src/urg_sensor.c
@@ -970,6 +970,7 @@ static int send_distance_command(urg_t *urg, int scan_times, int skip_scan,
         // \~english If the number of scans is over 99, work in infinite scanning mode
         urg->specified_scan_times = 0;
     }
+        urg->is_sending = URG_TRUE;
 
     if (urg->scanning_remain_times == 1) {
         // \~japanese  レーザ発光を指示
@@ -988,7 +989,6 @@ static int send_distance_command(urg_t *urg, int scan_times, int skip_scan,
                               urg->scanning_last_step + front_index,
                               urg->scanning_skip_step,
                               skip_scan, urg->specified_scan_times);
-        urg->is_sending = URG_TRUE;
     }
 
     n = connection_write(&urg->connection, buffer, write_size);


### PR DESCRIPTION
不具合：
・非対応の逐次取得系コマンドを送信した後の、get_*関数の応答が0になる。	
・MSコマンドのget関数の戻り値が-5（無応答）になっている。（wireShark上では正常応答が帰ってきている）

原因：
・逐次取得取得系コマンドの送信時に、構造体urgのis_sendingフラグをtrueにしない。
・取得系コマンドの応答が不正応答だった場合、ライブラリ内で、ignore_receive_data_with_qtというメソッドを呼んで、QTを送信した後にすべてのバッファを捨てる処理を行うが、is_sendingがtrueでないときはバッファを捨てない仕様になっていた。結果的に、そのあとGGコマンドの応答を見るときに、バッファの先頭にあるQTコマンドの応答を見ているので、戻り値が0になる。
・MSの応答が無応答になっていたのは、上記のずれが原因でHDとHEの無応答の結果をMSの応答の代わりに見ていたから。
・HEとHDが無応答なのは使用していた20LXのファームに問題がありそう。（3秒のタイムアウトを設けても応答がない）

対処：urgLibraryのsend_distance_command関数内でscan_times==1の時もis_sendingをtrueにする。
